### PR TITLE
Fix month navigation state

### DIFF
--- a/app/src/main/java/com/example/just_right_calendar/MainActivity.kt
+++ b/app/src/main/java/com/example/just_right_calendar/MainActivity.kt
@@ -18,7 +18,8 @@ class MainActivity : AppCompatActivity() {
 
     private lateinit var calendarGrid: GridLayout
     private lateinit var monthLabel: TextView
-    private var currentYearMonth: YearMonth = YearMonth.now()
+    private var currentYear: Int = YearMonth.now().year
+    private var currentMonth: Int = YearMonth.now().monthValue
     private val today: LocalDate = LocalDate.now()
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -30,17 +31,29 @@ class MainActivity : AppCompatActivity() {
         monthLabel = findViewById(R.id.monthLabel)
 
         findViewById<View>(R.id.prevButton).setOnClickListener {
-            currentYearMonth = currentYearMonth.minusMonths(1)
+            if (currentMonth == 1) {
+                currentYear -= 1
+                currentMonth = 12
+            } else {
+                currentMonth -= 1
+            }
             renderCalendar()
         }
 
         findViewById<View>(R.id.nextButton).setOnClickListener {
-            currentYearMonth = currentYearMonth.plusMonths(1)
+            if (currentMonth == 12) {
+                currentYear += 1
+                currentMonth = 1
+            } else {
+                currentMonth += 1
+            }
             renderCalendar()
         }
 
         findViewById<View>(R.id.todayButton).setOnClickListener {
-            currentYearMonth = YearMonth.now()
+            val now = YearMonth.now()
+            currentYear = now.year
+            currentMonth = now.monthValue
             renderCalendar()
         }
 
@@ -53,7 +66,9 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun renderCalendar() {
-        monthLabel.text = getString(R.string.month_format, currentYearMonth.year, currentYearMonth.monthValue)
+        monthLabel.text = getString(R.string.month_format, currentYear, currentMonth)
+
+        val currentYearMonth = YearMonth.of(currentYear, currentMonth)
 
         calendarGrid.removeAllViews()
         calendarGrid.columnCount = 7


### PR DESCRIPTION
## Summary
- keep the currently displayed year and month as explicit state values
- update the prev/next/today buttons to adjust the month with proper year rollover
- rerender the calendar grid based on the updated month state

## Testing
- ./gradlew test *(fails: SDK location not found in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940ab55a6dc8321a84b6e7645efc114)