### PR TITLE
Fix toolbar title duplication and header layout

### DIFF
--- a/app/src/main/java/com/example/just_right_calendar/MainActivity.kt
+++ b/app/src/main/java/com/example/just_right_calendar/MainActivity.kt
@@ -33,7 +33,9 @@ class MainActivity : AppCompatActivity() {
         setSupportActionBar(toolbar)
         supportActionBar?.setDisplayShowTitleEnabled(false)
         supportActionBar?.title = ""
+        supportActionBar?.subtitle = ""
         toolbar.title = ""
+        toolbar.subtitle = ""
 
         calendarGrid = findViewById(R.id.calendarGrid)
         monthLabel = findViewById(R.id.monthLabel)

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -70,12 +70,7 @@
                     android:textSize="20sp"
                     android:textStyle="bold"
                     android:padding="4dp"
-                    android:layout_marginStart="4dp" />
-
-                <View
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1" />
+                    android:layout_marginStart="12dp" />
 
                 <Button
                     android:id="@+id/todayButton"
@@ -86,7 +81,13 @@
                     android:textColor="@color/text_on_button"
                     android:paddingStart="12dp"
                     android:paddingEnd="12dp"
+                    android:layout_marginStart="8dp"
                     android:layout_marginEnd="8dp" />
+
+                <View
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1" />
 
                 <ImageButton
                     android:id="@+id/nextButton"


### PR DESCRIPTION
## Summary
- disable the default Toolbar title/subtitle to avoid overlapping labels and rely on the custom title view
- reorder the header row so month label and Today button sit together with spacing before the next-month control

## Testing
- ./gradlew test *(fails: Android SDK location not configured in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940cbf149cc83218febcf82d2383316)