### PR TITLE
Ensure calendar grid fills portrait layout

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -37,7 +37,7 @@
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:orientation="vertical"
             android:padding="16dp">
 


### PR DESCRIPTION
## Summary
- keep the main scroll container at full height in portrait layouts to maintain space for the calendar grid

## Testing
- gradlew test *(fails: Android SDK path not configured in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940ceea1c808321b6a12556e9fd09e7)