### PR TITLE
Fix duplicate toolbar title display

### DIFF
--- a/app/src/main/java/com/example/just_right_calendar/MainActivity.kt
+++ b/app/src/main/java/com/example/just_right_calendar/MainActivity.kt
@@ -31,8 +31,8 @@ class MainActivity : AppCompatActivity() {
 
         val toolbar: Toolbar = findViewById(R.id.topAppBar)
         setSupportActionBar(toolbar)
-        supportActionBar?.title = getString(R.string.app_name)
-        supportActionBar?.setDisplayShowTitleEnabled(true)
+        supportActionBar?.setDisplayShowTitleEnabled(false)
+        toolbar.title = getString(R.string.app_name)
 
         calendarGrid = findViewById(R.id.calendarGrid)
         monthLabel = findViewById(R.id.monthLabel)


### PR DESCRIPTION
## Summary
- disable the ActionBar title rendering and set the toolbar title directly to avoid overlapping titles

## Testing
- ./gradlew test *(fails: Android SDK location not configured in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940daaa81ec832195caa6823990ccfd)