### PR TITLE
Ensure toolbar only shows app title

### DIFF
--- a/app/src/main/java/com/example/just_right_calendar/MainActivity.kt
+++ b/app/src/main/java/com/example/just_right_calendar/MainActivity.kt
@@ -32,7 +32,10 @@ class MainActivity : AppCompatActivity() {
         val toolbar: Toolbar = findViewById(R.id.topAppBar)
         setSupportActionBar(toolbar)
         supportActionBar?.setDisplayShowTitleEnabled(false)
-        toolbar.title = getString(R.string.app_name)
+        toolbar.title = ""
+        toolbar.subtitle = ""
+        val toolbarTitle = toolbar.findViewById<TextView>(R.id.toolbarTitle)
+        toolbarTitle.text = getString(R.string.app_name)
 
         calendarGrid = findViewById(R.id.calendarGrid)
         monthLabel = findViewById(R.id.monthLabel)

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -15,8 +15,18 @@
             android:layout_height="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
             android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-            app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-            app:title="@string/app_name" />
+            app:popupTheme="@style/ThemeOverlay.AppCompat.Light">
+
+            <TextView
+                android:id="@+id/toolbarTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:text="@string/app_name"
+                android:textColor="@color/white"
+                android:textSize="20sp"
+                android:textStyle="bold" />
+        </androidx.appcompat.widget.Toolbar>
     </com.google.android.material.appbar.AppBarLayout>
 
     <LinearLayout


### PR DESCRIPTION
## Summary
- Replace toolbar title display with a dedicated TextView inside the toolbar
- Clear default action bar titles/subtitles and keep the custom toolbar title text to the app name

## Testing
- `./gradlew test` *(fails: Android SDK location not configured in environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940df9a775883219c227dec2fe40da7)