### PR TITLE
Disable toolbar default titles in MainActivity

### DIFF
--- a/app/src/main/java/com/example/just_right_calendar/MainActivity.kt
+++ b/app/src/main/java/com/example/just_right_calendar/MainActivity.kt
@@ -32,6 +32,8 @@ class MainActivity : AppCompatActivity() {
         val toolbar: Toolbar = findViewById(R.id.topAppBar)
         setSupportActionBar(toolbar)
         supportActionBar?.setDisplayShowTitleEnabled(false)
+        supportActionBar?.title = ""
+        supportActionBar?.subtitle = ""
         toolbar.title = ""
         toolbar.subtitle = ""
         val toolbarTitle = toolbar.findViewById<TextView>(R.id.toolbarTitle)
@@ -62,6 +64,15 @@ class MainActivity : AppCompatActivity() {
         }
 
         renderCalendar()
+    }
+
+    override fun onPostResume() {
+        super.onPostResume()
+        val toolbar: Toolbar = findViewById(R.id.topAppBar)
+        toolbar.title = ""
+        toolbar.subtitle = ""
+        supportActionBar?.title = ""
+        supportActionBar?.subtitle = ""
     }
 
     override fun onResume() {


### PR DESCRIPTION
## Summary
- disable the default Toolbar title and subtitle in MainActivity to rely solely on the custom toolbar title view
- clear Toolbar and action bar titles again in onPostResume to prevent delayed default titles from reappearing

## Testing
- `./gradlew test` *(fails: Android SDK location not configured in this environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940e30678c88321a59b456845dd602e)