### PR TITLE
Ensure toolbar remains blank and header below

### DIFF
--- a/app/src/main/java/com/example/just_right_calendar/MainActivity.kt
+++ b/app/src/main/java/com/example/just_right_calendar/MainActivity.kt
@@ -12,6 +12,7 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import com.google.android.material.appbar.MaterialToolbar
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.YearMonth
@@ -20,6 +21,7 @@ class MainActivity : AppCompatActivity() {
 
     private lateinit var calendarGrid: GridLayout
     private lateinit var monthLabel: TextView
+    private lateinit var toolbar: MaterialToolbar
     private var currentYearMonth: YearMonth = YearMonth.now()
     private val today: LocalDate = LocalDate.now()
 
@@ -28,8 +30,14 @@ class MainActivity : AppCompatActivity() {
         CalendarRepository.initialize(applicationContext)
         setContentView(R.layout.activity_main)
 
+        toolbar = findViewById(R.id.topAppBar)
         calendarGrid = findViewById(R.id.calendarGrid)
         monthLabel = findViewById(R.id.monthLabel)
+
+        setSupportActionBar(toolbar)
+        supportActionBar?.setDisplayShowTitleEnabled(false)
+        supportActionBar?.title = ""
+        supportActionBar?.subtitle = ""
 
         findViewById<View>(R.id.prevButton).setOnClickListener {
             val message = "prev clicked: $currentYearMonth"
@@ -53,6 +61,9 @@ class MainActivity : AppCompatActivity() {
         }
 
         renderCalendar()
+
+        toolbar.title = ""
+        toolbar.subtitle = ""
     }
 
     override fun onResume() {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,21 +5,12 @@
     android:layout_height="match_parent"
     android:background="@color/surface_background">
 
-    <LinearLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/topAppBar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="?attr/actionBarSize"
         android:background="@color/purple_500"
-        android:gravity="center"
-        android:padding="16dp">
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/app_name"
-            android:textColor="@color/white"
-            android:textSize="20sp"
-            android:textStyle="bold" />
-    </LinearLayout>
+        app:contentInsetStartWithNavigation="0dp" />
 
     <LinearLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
## Summary
- replace the top bar with an empty MaterialToolbar and keep the header controls below it
- ensure MainActivity clears the Toolbar title and subtitle both on setup and after initialization

## Testing
- ./gradlew test *(fails: Android SDK not configured in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940e792ab94832189c5b1564f664a27)