### PR TITLE
Fix calendar header layout below toolbar

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,16 +5,22 @@
     android:layout_height="match_parent"
     android:background="@color/surface_background">
 
-    <com.google.android.material.appbar.MaterialToolbar
-        android:id="@+id/topAppBar"
+    <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
-        android:background="@color/purple_500"
-        app:contentInsetStartWithNavigation="0dp" />
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/topAppBar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="@color/purple_500"
+            app:contentInsetStartWithNavigation="0dp" />
+    </com.google.android.material.appbar.AppBarLayout>
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:layout_marginTop="?attr/actionBarSize"
         android:orientation="vertical"
         android:padding="16dp">
 


### PR DESCRIPTION
## Summary
- wrap the toolbar inside an AppBarLayout to separate it from the main content
- offset the main content by the action bar height so the header stays below the toolbar

## Testing
- ./gradlew test *(fails: SDK location not found in CI environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940f1bc7bac8321920a882cf98a9c96)