### PR TITLE
Add mark selection and restyle today button

### DIFF
--- a/app/src/main/java/com/example/just_right_calendar/MainActivity.kt
+++ b/app/src/main/java/com/example/just_right_calendar/MainActivity.kt
@@ -125,11 +125,11 @@ class MainActivity : AppCompatActivity() {
         val topArea = view.findViewById<LinearLayout>(R.id.dayTopArea)
         val bottomArea = view.findViewById<LinearLayout>(R.id.dayBottomArea)
         val dayNumber = view.findViewById<TextView>(R.id.dayNumber)
-        val memoText = view.findViewById<TextView>(R.id.memoText)
+        val markText = view.findViewById<TextView>(R.id.markText)
 
         dayNumber.text = date.dayOfMonth.toString()
 
-        val isHoliday = holidays.containsKey(date) || CalendarRepository.getCustomHoliday(date) != null || date.dayOfWeek == DayOfWeek.SUNDAY
+        val isHoliday = holidays.containsKey(date) || date.dayOfWeek == DayOfWeek.SUNDAY
         val isSaturday = date.dayOfWeek == DayOfWeek.SATURDAY
 
         val topColor = when {
@@ -142,9 +142,10 @@ class MainActivity : AppCompatActivity() {
         val bottomColor = if (date == today) ContextCompat.getColor(this, R.color.today_green) else Color.WHITE
         bottomArea.setBackgroundColor(bottomColor)
 
-        val memo = CalendarRepository.getMemo(date)
-        memoText.text = memo ?: ""
-        memoText.visibility = if (memo.isNullOrBlank()) View.GONE else View.VISIBLE
+        val marks = CalendarRepository.getMarks(date)
+        val markSymbols = marks.joinToString("") { it.symbol }
+        markText.text = markSymbols
+        markText.visibility = if (marks.isEmpty()) View.GONE else View.VISIBLE
 
         view.setOnClickListener {
             val intent = Intent(this, DayDetailActivity::class.java).apply {

--- a/app/src/main/java/com/example/just_right_calendar/MarkType.kt
+++ b/app/src/main/java/com/example/just_right_calendar/MarkType.kt
@@ -1,0 +1,13 @@
+package com.example.just_right_calendar
+
+enum class MarkType(val symbol: String) {
+    CIRCLE("〇"),
+    CHECK("✓"),
+    STAR("☆");
+
+    companion object {
+        fun fromString(value: String?): MarkType? {
+            return values().firstOrNull { it.name.equals(value, ignoreCase = true) }
+        }
+    }
+}

--- a/app/src/main/res/drawable/bg_today_button.xml
+++ b/app/src/main/res/drawable/bg_today_button.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="#9EAFB7" />
+            <corners android:radius="10dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="#B0BEC5" />
+            <corners android:radius="10dp" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/layout/activity_day_detail.xml
+++ b/app/src/main/res/layout/activity_day_detail.xml
@@ -30,57 +30,42 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/memo_label"
+            android:text="マーク"
             android:textColor="@color/text_primary"
-            android:textSize="14sp" />
-
-        <EditText
-            android:id="@+id/memoInput"
-            android:layout_width="match_parent"
-            android:layout_height="120dp"
-            android:gravity="top|start"
-            android:background="@drawable/input_background"
-            android:padding="12dp"
-            android:textColor="@color/text_primary"
-            android:textColorHint="@color/text_secondary"
-            android:hint="@string/memo_hint"
-            android:inputType="textMultiLine|textCapSentences|textImeMultiLine"
-            android:singleLine="false"
-            android:scrollHorizontally="false"
-            android:layout_marginBottom="16dp" />
+            android:textSize="14sp"
+            android:paddingBottom="8dp" />
 
         <LinearLayout
             android:orientation="horizontal"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:gravity="center_vertical"
-            android:paddingBottom="8dp">
+            android:gravity="start"
+            android:paddingBottom="16dp"
+            android:dividerPadding="8dp">
 
-            <TextView
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="@string/custom_holiday_label"
-                android:textColor="@color/text_primary"
-                android:textSize="14sp" />
-
-            <Switch
-                android:id="@+id/customHolidaySwitch"
+            <CheckBox
+                android:id="@+id/markCircle"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content" />
-        </LinearLayout>
+                android:layout_height="wrap_content"
+                android:text="〇"
+                android:textSize="18sp" />
 
-        <EditText
-            android:id="@+id/customHolidayName"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="@string/custom_holiday_hint"
-            android:background="@drawable/input_background"
-            android:padding="12dp"
-            android:textColor="@color/text_primary"
-            android:textColorHint="@color/text_secondary"
-            android:enabled="false"
-            android:layout_marginBottom="16dp" />
+            <CheckBox
+                android:id="@+id/markCheck"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="✓"
+                android:textSize="18sp"
+                android:layout_marginStart="16dp" />
+
+            <CheckBox
+                android:id="@+id/markStar"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="☆"
+                android:textSize="18sp"
+                android:layout_marginStart="16dp" />
+        </LinearLayout>
 
         <LinearLayout
             android:orientation="horizontal"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -68,11 +68,15 @@
                     android:id="@+id/todayButton"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:backgroundTint="@color/button_tint"
+                    android:background="@drawable/bg_today_button"
                     android:paddingStart="12dp"
                     android:paddingEnd="12dp"
+                    android:paddingTop="6dp"
+                    android:paddingBottom="6dp"
                     android:text="@string/today"
-                    android:textColor="@color/text_on_button" />
+                    android:textColor="@color/text_on_button"
+                    android:textSize="12sp"
+                    android:elevation="3dp" />
             </LinearLayout>
 
             <ImageButton

--- a/app/src/main/res/layout/day_cell.xml
+++ b/app/src/main/res/layout/day_cell.xml
@@ -39,13 +39,13 @@
         android:paddingBottom="4dp">
 
         <TextView
-            android:id="@+id/memoText"
+            android:id="@+id/markText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:gravity="end"
             android:textColor="@color/text_primary"
             android:textSize="12sp"
-            android:maxLines="2"
-            android:ellipsize="end" />
+            android:maxLines="1" />
     </LinearLayout>
 
 </LinearLayout>


### PR DESCRIPTION
## Summary
- replace memo/custom holiday handling with selectable marks and persistence
- show selected marks on the calendar cells and streamline day detail UI
- restyle the today button with a compact blue-gray background and elevation

## Testing
- `./gradlew test` *(fails: SDK location not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940f9562f288321b5a40d43abfcbffe)