### PR TITLE
Position calendar marks at bottom center

### DIFF
--- a/app/src/main/java/com/example/just_right_calendar/MainActivity.kt
+++ b/app/src/main/java/com/example/just_right_calendar/MainActivity.kt
@@ -143,8 +143,8 @@ class MainActivity : AppCompatActivity() {
         bottomArea.setBackgroundColor(bottomColor)
 
         val marks = CalendarRepository.getMarks(date)
-        val markSymbols = marks.joinToString("") { it.symbol }
-        markText.text = markSymbols
+        val markSymbol = marks.firstOrNull()?.symbol.orEmpty()
+        markText.text = markSymbol
         markText.visibility = if (marks.isEmpty()) View.GONE else View.VISIBLE
 
         view.setOnClickListener {

--- a/app/src/main/res/layout/day_cell.xml
+++ b/app/src/main/res/layout/day_cell.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="0dp"
     android:layout_height="0dp"
     android:layout_weight="1"
@@ -9,43 +8,55 @@
     android:padding="1dp">
 
     <LinearLayout
-        android:id="@+id/dayTopArea"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center_vertical"
-        android:paddingStart="6dp"
-        android:paddingEnd="6dp"
-        android:paddingTop="4dp"
-        android:paddingBottom="4dp">
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
-        <TextView
-            android:id="@+id/dayNumber"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textColor="@color/text_primary"
-            android:textSize="16sp"
-            android:textStyle="bold" />
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/dayBottomArea"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:orientation="vertical"
-        android:paddingStart="6dp"
-        android:paddingEnd="6dp"
-        android:paddingTop="2dp"
-        android:paddingBottom="4dp">
-
-        <TextView
-            android:id="@+id/markText"
+        <LinearLayout
+            android:id="@+id/dayTopArea"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:gravity="end"
-            android:textColor="@color/text_primary"
-            android:textSize="12sp"
-            android:maxLines="1" />
+            android:gravity="center_vertical"
+            android:paddingStart="6dp"
+            android:paddingEnd="6dp"
+            android:paddingTop="4dp"
+            android:paddingBottom="4dp">
+
+            <TextView
+                android:id="@+id/dayNumber"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/text_primary"
+                android:textSize="16sp"
+                android:textStyle="bold" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/dayBottomArea"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="vertical"
+            android:paddingStart="6dp"
+            android:paddingEnd="6dp"
+            android:paddingTop="2dp"
+            android:paddingBottom="4dp" />
     </LinearLayout>
 
-</LinearLayout>
+    <TextView
+        android:id="@+id/markText"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center_horizontal|bottom"
+        android:paddingBottom="8dp"
+        android:textColor="#D32F2F"
+        android:textSize="32sp"
+        android:textStyle="bold"
+        android:includeFontPadding="false"
+        android:maxLines="1"
+        android:autoSizeTextType="uniform"
+        android:autoSizeMinTextSize="18sp"
+        android:autoSizeMaxTextSize="54sp"
+        android:autoSizeStepGranularity="2sp" />
+
+</FrameLayout>


### PR DESCRIPTION
## Summary
- overlay calendar marks at the bottom center of each cell with bold red styling
- ensure marks auto-size near cell height and appear above day numbers without overlap
- limit daily mark display to a single symbol

## Testing
- ./gradlew test *(fails: Android SDK location not configured in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940fb738f1083218d89737aef75f007)