### PR TITLE
Handle day cell inflation without casting

### DIFF
--- a/app/src/main/java/com/example/just_right_calendar/MainActivity.kt
+++ b/app/src/main/java/com/example/just_right_calendar/MainActivity.kt
@@ -101,7 +101,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun createEmptyCell(): View {
         val inflater = LayoutInflater.from(this)
-        val view = inflater.inflate(R.layout.day_cell, calendarGrid, false) as LinearLayout
+        val view = inflater.inflate(R.layout.day_cell, calendarGrid, false)
         val params = GridLayout.LayoutParams().apply {
             width = 0
             height = GridLayout.LayoutParams.WRAP_CONTENT
@@ -114,7 +114,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun createDayCell(date: LocalDate, holidays: Map<LocalDate, String>): View {
         val inflater = LayoutInflater.from(this)
-        val view = inflater.inflate(R.layout.day_cell, calendarGrid, false) as LinearLayout
+        val view = inflater.inflate(R.layout.day_cell, calendarGrid, false)
         val params = GridLayout.LayoutParams().apply {
             width = 0
             height = GridLayout.LayoutParams.WRAP_CONTENT


### PR DESCRIPTION
## Summary
- avoid casting the inflated day_cell layout to LinearLayout so the root view type is flexible
- continue configuring layout params and child bindings via findViewById to render cells safely

## Testing
- ./gradlew test *(fails: SDK location not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940fdd3e008832192f1bd3831bd77ea)