### PR TITLE
Adjust today button and mark positioning

### DIFF
--- a/app/src/main/java/com/example/just_right_calendar/MainActivity.kt
+++ b/app/src/main/java/com/example/just_right_calendar/MainActivity.kt
@@ -4,8 +4,11 @@ import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
 import android.util.Log
+import android.util.TypedValue
+import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import android.widget.GridLayout
 import android.widget.LinearLayout
 import android.widget.TextView
@@ -126,6 +129,17 @@ class MainActivity : AppCompatActivity() {
         val bottomArea = view.findViewById<LinearLayout>(R.id.dayBottomArea)
         val dayNumber = view.findViewById<TextView>(R.id.dayNumber)
         val markText = view.findViewById<TextView>(R.id.markText)
+
+        val markParams = markText.layoutParams
+        if (markParams is ViewGroup.MarginLayoutParams) {
+            markParams.bottomMargin = resources.getDimensionPixelSize(R.dimen.mark_bottom_margin)
+            markText.layoutParams = markParams
+        }
+        val bottomPadding = resources.getDimensionPixelSize(R.dimen.mark_bottom_padding)
+        markText.setPadding(markText.paddingLeft, markText.paddingTop, markText.paddingRight, bottomPadding)
+        markText.gravity = Gravity.CENTER_HORIZONTAL or Gravity.BOTTOM
+        val markTextSize = resources.getDimension(R.dimen.mark_text_default_size)
+        markText.setTextSize(TypedValue.COMPLEX_UNIT_PX, markTextSize)
 
         dayNumber.text = date.dayOfMonth.toString()
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -69,14 +69,14 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:background="@drawable/bg_today_button"
-                    android:paddingStart="12dp"
-                    android:paddingEnd="12dp"
-                    android:paddingTop="6dp"
-                    android:paddingBottom="6dp"
+                    android:paddingStart="11dp"
+                    android:paddingEnd="11dp"
+                    android:paddingTop="5dp"
+                    android:paddingBottom="5dp"
                     android:text="@string/today"
                     android:textColor="@color/text_on_button"
-                    android:textSize="12sp"
-                    android:elevation="3dp" />
+                    android:textSize="11sp"
+                    android:elevation="2dp" />
             </LinearLayout>
 
             <ImageButton

--- a/app/src/main/res/layout/day_cell.xml
+++ b/app/src/main/res/layout/day_cell.xml
@@ -48,15 +48,15 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:gravity="center_horizontal|bottom"
-        android:paddingBottom="8dp"
+        android:paddingBottom="@dimen/mark_bottom_padding"
         android:textColor="#D32F2F"
-        android:textSize="32sp"
+        android:textSize="@dimen/mark_text_default_size"
         android:textStyle="bold"
         android:includeFontPadding="false"
         android:maxLines="1"
         android:autoSizeTextType="uniform"
-        android:autoSizeMinTextSize="18sp"
-        android:autoSizeMaxTextSize="54sp"
+        android:autoSizeMinTextSize="16sp"
+        android:autoSizeMaxTextSize="48sp"
         android:autoSizeStepGranularity="2sp" />
 
 </FrameLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<resources>
+    <dimen name="mark_bottom_padding">10dp</dimen>
+    <dimen name="mark_bottom_margin">6dp</dimen>
+    <dimen name="mark_text_default_size">29sp</dimen>
+</resources>


### PR DESCRIPTION
## Summary
- reduce the Today button sizing and elevation while keeping its rounded blue-gray styling
- reposition and scale down day cell marks with padding and margins to keep them centered near the bottom without overlapping dates

## Testing
- ./gradlew test *(fails: Android SDK not configured in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940ff9196108321b200352cb2ffe1fa)