### PR TITLE
Align day cell marks to bottom center

### DIFF
--- a/app/src/main/java/com/example/just_right_calendar/MainActivity.kt
+++ b/app/src/main/java/com/example/just_right_calendar/MainActivity.kt
@@ -9,6 +9,7 @@ import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.FrameLayout
 import android.widget.GridLayout
 import android.widget.LinearLayout
 import android.widget.TextView
@@ -131,13 +132,21 @@ class MainActivity : AppCompatActivity() {
         val markText = view.findViewById<TextView>(R.id.markText)
 
         val markParams = markText.layoutParams
-        if (markParams is ViewGroup.MarginLayoutParams) {
-            markParams.bottomMargin = resources.getDimensionPixelSize(R.dimen.mark_bottom_margin)
-            markText.layoutParams = markParams
+        val bottomMargin = resources.getDimensionPixelSize(R.dimen.mark_bottom_margin)
+        when (markParams) {
+            is FrameLayout.LayoutParams -> {
+                markParams.gravity = Gravity.BOTTOM or Gravity.CENTER_HORIZONTAL
+                markParams.bottomMargin = bottomMargin
+                markText.layoutParams = markParams
+            }
+            is ViewGroup.MarginLayoutParams -> {
+                markParams.bottomMargin = bottomMargin
+                markText.layoutParams = markParams
+            }
         }
         val bottomPadding = resources.getDimensionPixelSize(R.dimen.mark_bottom_padding)
         markText.setPadding(markText.paddingLeft, markText.paddingTop, markText.paddingRight, bottomPadding)
-        markText.gravity = Gravity.CENTER_HORIZONTAL or Gravity.BOTTOM
+        markText.gravity = Gravity.CENTER
         val markTextSize = resources.getDimension(R.dimen.mark_text_default_size)
         markText.setTextSize(TypedValue.COMPLEX_UNIT_PX, markTextSize)
 

--- a/app/src/main/res/layout/day_cell.xml
+++ b/app/src/main/res/layout/day_cell.xml
@@ -45,10 +45,11 @@
 
     <TextView
         android:id="@+id/markText"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:gravity="center_horizontal|bottom"
-        android:paddingBottom="@dimen/mark_bottom_padding"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal|bottom"
+        android:layout_marginBottom="@dimen/mark_bottom_margin"
+        android:gravity="center"
         android:textColor="#D32F2F"
         android:textSize="@dimen/mark_text_default_size"
         android:textStyle="bold"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,5 +1,5 @@
 <resources>
-    <dimen name="mark_bottom_padding">10dp</dimen>
-    <dimen name="mark_bottom_margin">6dp</dimen>
+    <dimen name="mark_bottom_padding">0dp</dimen>
+    <dimen name="mark_bottom_margin">5dp</dimen>
     <dimen name="mark_text_default_size">29sp</dimen>
 </resources>


### PR DESCRIPTION
## Summary
- Anchor calendar mark symbols to the bottom center of each day cell via layout params to avoid misalignment
- Adjust mark spacing dimensions for consistent 5dp bottom gap without extra padding
- Guard layout parameter handling to prevent class cast issues while setting gravity and margins

## Testing
- `./gradlew test` *(fails: Android SDK not configured in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694101802dac83219e1516df0bd4047b)