### PR TITLE
Adjust today button color and mark alignment

### DIFF
--- a/app/src/main/res/drawable/bg_today_button.xml
+++ b/app/src/main/res/drawable/bg_today_button.xml
@@ -2,13 +2,13 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_pressed="true">
         <shape android:shape="rectangle">
-            <solid android:color="#9EAFB7" />
+            <solid android:color="#A7B6BE" />
             <corners android:radius="10dp" />
         </shape>
     </item>
     <item>
         <shape android:shape="rectangle">
-            <solid android:color="#B0BEC5" />
+            <solid android:color="#B8C4CC" />
             <corners android:radius="10dp" />
         </shape>
     </item>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -69,6 +69,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:background="@drawable/bg_today_button"
+                    android:backgroundTint="@null"
                     android:paddingStart="11dp"
                     android:paddingEnd="11dp"
                     android:paddingTop="5dp"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,5 +1,5 @@
 <resources>
     <dimen name="mark_bottom_padding">0dp</dimen>
-    <dimen name="mark_bottom_margin">5dp</dimen>
+    <dimen name="mark_bottom_margin">9.5dp</dimen>
     <dimen name="mark_text_default_size">29sp</dimen>
 </resources>


### PR DESCRIPTION
## Summary
- update the Today button background to a blue-gray palette and disable theme tinting so it no longer appears purple
- keep the compact button sizing while maintaining its rounded corners and light elevation
- lower the date cell marks by roughly 2pt via the shared bottom margin resource

## Testing
- ./gradlew test *(fails: Android SDK not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941061202ac8321b4dfad2691bd752f)