### PR TITLE
Adjust today button sizing and mark alignment

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -70,13 +70,15 @@
                     android:layout_height="wrap_content"
                     android:background="@drawable/bg_today_button"
                     android:backgroundTint="@null"
-                    android:paddingStart="11dp"
-                    android:paddingEnd="11dp"
-                    android:paddingTop="5dp"
-                    android:paddingBottom="5dp"
+                    android:minWidth="0dp"
+                    android:minHeight="0dp"
+                    android:paddingStart="8dp"
+                    android:paddingEnd="8dp"
+                    android:paddingTop="3dp"
+                    android:paddingBottom="3dp"
                     android:text="@string/today"
                     android:textColor="@color/text_on_button"
-                    android:textSize="11sp"
+                    android:textSize="10sp"
                     android:elevation="2dp" />
             </LinearLayout>
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,5 +1,5 @@
 <resources>
     <dimen name="mark_bottom_padding">0dp</dimen>
-    <dimen name="mark_bottom_margin">9.5dp</dimen>
+    <dimen name="mark_bottom_margin">-4dp</dimen>
     <dimen name="mark_text_default_size">29sp</dimen>
 </resources>


### PR DESCRIPTION
## Summary
- reduce the Today button padding and text size while removing minimum dimension constraints to make it visibly smaller
- adjust the mark bottom margin to anchor the icon lower in the cell while keeping horizontal centering

## Testing
- ./gradlew test (fails: Android SDK not configured in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694108053eac83219f97d09e0c726263)