### PR TITLE
Add user holiday toggle and fix today button styling

### DIFF
--- a/app/src/main/java/com/example/just_right_calendar/CalendarRepository.kt
+++ b/app/src/main/java/com/example/just_right_calendar/CalendarRepository.kt
@@ -7,6 +7,7 @@ import java.time.LocalDate
 object CalendarRepository {
     private const val PREF_NAME = "calendar_prefs"
     private const val MARK_KEY_PREFIX = "marks_"
+    private const val HOLIDAY_KEY_PREFIX = "holiday_"
 
     private lateinit var prefs: SharedPreferences
 
@@ -23,6 +24,11 @@ object CalendarRepository {
             .toSet()
     }
 
+    fun isUserHoliday(date: LocalDate): Boolean {
+        if (!::prefs.isInitialized) throw IllegalStateException("CalendarRepository is not initialized")
+        return prefs.getBoolean(holidayKey(date), false)
+    }
+
     fun saveMarks(date: LocalDate, marks: Set<MarkType>) {
         if (!::prefs.isInitialized) throw IllegalStateException("CalendarRepository is not initialized")
         val editor = prefs.edit()
@@ -34,5 +40,17 @@ object CalendarRepository {
         editor.apply()
     }
 
+    fun saveHoliday(date: LocalDate, isHoliday: Boolean) {
+        if (!::prefs.isInitialized) throw IllegalStateException("CalendarRepository is not initialized")
+        val editor = prefs.edit()
+        if (isHoliday) {
+            editor.putBoolean(holidayKey(date), true)
+        } else {
+            editor.remove(holidayKey(date))
+        }
+        editor.apply()
+    }
+
     private fun marksKey(date: LocalDate): String = "$MARK_KEY_PREFIX${date}"
+    private fun holidayKey(date: LocalDate): String = "$HOLIDAY_KEY_PREFIX${date}"
 }

--- a/app/src/main/java/com/example/just_right_calendar/DayDetailActivity.kt
+++ b/app/src/main/java/com/example/just_right_calendar/DayDetailActivity.kt
@@ -7,6 +7,7 @@ import android.widget.TextView
 import androidx.activity.addCallback
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.SwitchCompat
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.YearMonth
@@ -23,7 +24,9 @@ class DayDetailActivity : AppCompatActivity() {
     private lateinit var circleCheck: CheckBox
     private lateinit var checkCheck: CheckBox
     private lateinit var starCheck: CheckBox
+    private lateinit var holidayToggle: SwitchCompat
     private var originalMarks: Set<MarkType> = emptySet()
+    private var originalHolidayFlag: Boolean = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -42,6 +45,7 @@ class DayDetailActivity : AppCompatActivity() {
         circleCheck = findViewById(R.id.markCircle)
         checkCheck = findViewById(R.id.markCheck)
         starCheck = findViewById(R.id.markStar)
+        holidayToggle = findViewById(R.id.holidayToggle)
         val saveButton = findViewById<Button>(R.id.saveButton)
 
         dateLabel.text = date.format(DateTimeFormatter.ofPattern("yyyy/MM/dd"))
@@ -52,6 +56,14 @@ class DayDetailActivity : AppCompatActivity() {
         checkCheck.isChecked = marks.contains(MarkType.CHECK)
         starCheck.isChecked = marks.contains(MarkType.STAR)
 
+        val userHoliday = CalendarRepository.isUserHoliday(date)
+        originalHolidayFlag = userHoliday
+        holidayToggle.isChecked = userHoliday
+
+        holidayToggle.setOnCheckedChangeListener { _, _ ->
+            updateDayTypeLabel()
+        }
+
         updateDayTypeLabel()
 
         onBackPressedDispatcher.addCallback(this) {
@@ -60,6 +72,7 @@ class DayDetailActivity : AppCompatActivity() {
 
         saveButton.setOnClickListener {
             CalendarRepository.saveMarks(date, collectSelectedMarks())
+            CalendarRepository.saveHoliday(date, collectHolidayFlag())
             finish()
         }
     }
@@ -71,6 +84,8 @@ class DayDetailActivity : AppCompatActivity() {
         if (starCheck.isChecked) result.add(MarkType.STAR)
         return result
     }
+
+    private fun collectHolidayFlag(): Boolean = holidayToggle.isChecked
 
     private fun handleBackNavigation() {
         if (hasUnsavedChanges()) {
@@ -87,7 +102,8 @@ class DayDetailActivity : AppCompatActivity() {
 
     private fun hasUnsavedChanges(): Boolean {
         val currentMarks = collectSelectedMarks()
-        return currentMarks != originalMarks
+        val currentHolidayFlag = collectHolidayFlag()
+        return currentMarks != originalMarks || currentHolidayFlag != originalHolidayFlag
     }
 
     private fun updateDayTypeLabel() {
@@ -95,6 +111,7 @@ class DayDetailActivity : AppCompatActivity() {
         val nationalHoliday = holidays[date]
 
         val label = when {
+            holidayToggle.isChecked -> getString(R.string.user_holiday_label)
             nationalHoliday != null -> "$nationalHoliday (祝日)"
             date.dayOfWeek == DayOfWeek.SUNDAY -> "日曜"
             date.dayOfWeek == DayOfWeek.SATURDAY -> "土曜"

--- a/app/src/main/java/com/example/just_right_calendar/MainActivity.kt
+++ b/app/src/main/java/com/example/just_right_calendar/MainActivity.kt
@@ -152,7 +152,8 @@ class MainActivity : AppCompatActivity() {
 
         dayNumber.text = date.dayOfMonth.toString()
 
-        val isHoliday = holidays.containsKey(date) || date.dayOfWeek == DayOfWeek.SUNDAY
+        val isUserHoliday = CalendarRepository.isUserHoliday(date)
+        val isHoliday = isUserHoliday || holidays.containsKey(date) || date.dayOfWeek == DayOfWeek.SUNDAY
         val isSaturday = date.dayOfWeek == DayOfWeek.SATURDAY
 
         val topColor = when {

--- a/app/src/main/res/drawable/bg_today_button.xml
+++ b/app/src/main/res/drawable/bg_today_button.xml
@@ -2,13 +2,13 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_pressed="true">
         <shape android:shape="rectangle">
-            <solid android:color="#A7B6BE" />
+            <solid android:color="@color/button_tint_pressed" />
             <corners android:radius="10dp" />
         </shape>
     </item>
     <item>
         <shape android:shape="rectangle">
-            <solid android:color="#B8C4CC" />
+            <solid android:color="@color/button_tint" />
             <corners android:radius="10dp" />
         </shape>
     </item>

--- a/app/src/main/res/layout/activity_day_detail.xml
+++ b/app/src/main/res/layout/activity_day_detail.xml
@@ -67,6 +67,22 @@
                 android:layout_marginStart="16dp" />
         </LinearLayout>
 
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/holiday_section_title"
+            android:textColor="@color/text_primary"
+            android:textSize="14sp"
+            android:paddingBottom="8dp" />
+
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/holidayToggle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/set_as_holiday"
+            android:textColor="@color/text_primary"
+            android:paddingBottom="16dp" />
+
         <LinearLayout
             android:orientation="horizontal"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -70,6 +70,7 @@
                     android:layout_height="wrap_content"
                     android:background="@drawable/bg_today_button"
                     android:backgroundTint="@null"
+                    app:backgroundTint="@null"
                     android:minWidth="0dp"
                     android:minHeight="0dp"
                     android:paddingStart="8dp"

--- a/app/src/main/res/layout/day_cell.xml
+++ b/app/src/main/res/layout/day_cell.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="0dp"
-    android:layout_height="0dp"
-    android:layout_weight="1"
+    android:layout_height="wrap_content"
     android:minHeight="72dp"
     android:background="@color/cell_border"
     android:padding="1dp">
@@ -15,7 +14,8 @@
         <LinearLayout
             android:id="@+id/dayTopArea"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="0dp"
+            android:layout_weight="1"
             android:gravity="center_vertical"
             android:paddingStart="6dp"
             android:paddingEnd="6dp"
@@ -31,33 +31,36 @@
                 android:textStyle="bold" />
         </LinearLayout>
 
-        <LinearLayout
-            android:id="@+id/dayBottomArea"
+        <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:orientation="vertical"
-            android:paddingStart="6dp"
-            android:paddingEnd="6dp"
-            android:paddingTop="2dp"
-            android:paddingBottom="4dp" />
-    </LinearLayout>
+            android:layout_height="@dimen/day_bottom_area_height">
 
-    <TextView
-        android:id="@+id/markText"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal|bottom"
-        android:layout_marginBottom="@dimen/mark_bottom_margin"
-        android:gravity="center"
-        android:textColor="#D32F2F"
-        android:textSize="@dimen/mark_text_default_size"
-        android:textStyle="bold"
-        android:includeFontPadding="false"
-        android:maxLines="1"
-        android:autoSizeTextType="uniform"
-        android:autoSizeMinTextSize="16sp"
-        android:autoSizeMaxTextSize="48sp"
-        android:autoSizeStepGranularity="2sp" />
+            <LinearLayout
+                android:id="@+id/dayBottomArea"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical"
+                android:paddingStart="6dp"
+                android:paddingEnd="6dp"
+                android:paddingTop="2dp"
+                android:paddingBottom="4dp" />
+
+            <TextView
+                android:id="@+id/markText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:gravity="center"
+                android:textColor="#D32F2F"
+                android:textSize="@dimen/mark_text_default_size"
+                android:textStyle="bold"
+                android:includeFontPadding="false"
+                android:maxLines="1"
+                android:autoSizeTextType="uniform"
+                android:autoSizeMinTextSize="16sp"
+                android:autoSizeMaxTextSize="48sp"
+                android:autoSizeStepGranularity="2sp" />
+        </FrameLayout>
+    </LinearLayout>
 
 </FrameLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -17,5 +17,6 @@
     <color name="input_background">#FFFFFFFF</color>
     <color name="cell_border">#FFEFEFEF</color>
     <color name="button_tint">#FFB0BEC5</color>
+    <color name="button_tint_pressed">#FFA7B6BE</color>
     <color name="text_on_button">#FF111111</color>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -2,4 +2,5 @@
     <dimen name="mark_bottom_padding">0dp</dimen>
     <dimen name="mark_bottom_margin">-4dp</dimen>
     <dimen name="mark_text_default_size">29sp</dimen>
+    <dimen name="day_bottom_area_height">32dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,4 +19,7 @@
     <string name="discard_changes_title">編集内容を破棄しますか？</string>
     <string name="discard_changes_message">保存せずに前の画面へ戻ります。</string>
     <string name="discard">破棄する</string>
+    <string name="holiday_section_title">休日設定</string>
+    <string name="set_as_holiday">この日を休日にする</string>
+    <string name="user_holiday_label">ユーザー設定の休日</string>
 </resources>


### PR DESCRIPTION
## Summary
- keep the Today button styling fixed to the blue-gray drawable without theme tint
- stabilize day cell layout so the bottom highlight band has a consistent height
- add a user-holiday toggle that saves per-day flags and renders them as holidays on the calendar

## Testing
- ./gradlew test *(fails: Android SDK path not configured in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69410a462ef483219bbe41701b669abb)