### PR TITLE
Fix widget calendar XML declaration

### DIFF
--- a/app/src/main/res/layout/widget_calendar.xml
+++ b/app/src/main/res/layout/widget_calendar.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/widgetRoot"


### PR DESCRIPTION
## Summary
- rewrite widget_calendar.xml to remove the leading whitespace before the XML declaration so it starts correctly

## Testing
- ./gradlew assembleDebug *(fails: SDK location not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69432f1166808321beab83e918f901fe)