### PR TITLE
Adjust widget dimensions for visibility

### DIFF
--- a/app/src/main/res/xml/calendar_widget_info.xml
+++ b/app/src/main/res/xml/calendar_widget_info.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
-    android:minWidth="320dp"
-    android:minHeight="520dp"
+    android:minWidth="250dp"
+    android:minHeight="300dp"
     android:initialLayout="@layout/widget_calendar"
     android:updatePeriodMillis="0"
     android:resizeMode="horizontal|vertical"


### PR DESCRIPTION
## Summary
- reduce the app widget's minimum width and height so it can fit on typical home screen grids

## Testing
- not run (Android SDK not available in environment)
- ./gradlew test (fails: SDK location not configured)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69433828b2408321980043a2867f43cb)