### PR TITLE
Adjust widget sizing and layout defaults

### DIFF
--- a/app/src/main/java/com/example/just_right_calendar/CalendarRepository.kt
+++ b/app/src/main/java/com/example/just_right_calendar/CalendarRepository.kt
@@ -18,6 +18,7 @@ object CalendarRepository {
     }
 
     fun getMarks(date: LocalDate): Set<MarkType> {
+        if (!::prefs.isInitialized) throw IllegalStateException("CalendarRepository is not initialized")
         val raw = prefs.getString(marksKey(date), null) ?: return emptySet()
         return raw.split(',')
             .mapNotNull { MarkType.fromString(it.trim()) }

--- a/app/src/main/java/com/example/just_right_calendar/CalendarWidgetProvider.kt
+++ b/app/src/main/java/com/example/just_right_calendar/CalendarWidgetProvider.kt
@@ -121,6 +121,11 @@ class CalendarWidgetProvider : AppWidgetProvider() {
             val dayNumberIds = buildIdArray(context, "Number")
             val dayMarkIds = buildIdArray(context, "Mark")
 
+            val idArrays = listOf(dayContainerIds, dayTopIds, dayBottomIds, dayNumberIds, dayMarkIds)
+            if (idArrays.any { array -> array.any { it == 0 } }) {
+                return
+            }
+
             val views = RemoteViews(context.packageName, R.layout.widget_calendar)
             val yearMonth = loadYearMonth(context, appWidgetId)
             val firstDayOfMonth = yearMonth.atDay(1)

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -5,5 +5,5 @@
     <dimen name="mark_text_default_size">29sp</dimen>
     <dimen name="day_bottom_area_height">32dp</dimen>
     <dimen name="widget_mark_text_size">26sp</dimen>
-    <dimen name="widget_day_height">68dp</dimen>
+    <dimen name="widget_day_height">60dp</dimen>
 </resources>

--- a/app/src/main/res/xml/calendar_widget_info.xml
+++ b/app/src/main/res/xml/calendar_widget_info.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
-    android:minWidth="250dp"
-    android:minHeight="300dp"
+    android:minWidth="320dp"
+    android:minHeight="260dp"
     android:initialLayout="@layout/widget_calendar"
     android:updatePeriodMillis="0"
     android:resizeMode="horizontal|vertical"


### PR DESCRIPTION
## Summary
- Increase the calendar widget’s default width while reducing its default height to better match the requested proportions
- Decrease individual day cell height to create a more compact vertical layout
- Guard widget ID resolution to avoid update failures that lead to "Can't load widget"

## Testing
- ./gradlew test *(fails: SDK location not found in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69433b2ba3fc8321a0384fffb7447d2e)