### PR TITLE
Adjust day cell and widget display

### DIFF
--- a/app/src/main/java/com/example/just_right_calendar/CalendarWidgetProvider.kt
+++ b/app/src/main/java/com/example/just_right_calendar/CalendarWidgetProvider.kt
@@ -78,6 +78,7 @@ class CalendarWidgetProvider : AppWidgetProvider() {
 
     private fun buildRemoteViews(context: Context): RemoteViews? {
         Log.d(TAG, "buildRemoteViews start")
+        CalendarRepository.initialize(context.applicationContext)
         val packageName = context.packageName
         val numberIds = resolveIds(context, NUMBER_ID_PREFIX, NUMBER_ID_SUFFIX)
         val markIds = resolveIds(context, MARK_ID_PREFIX, MARK_ID_SUFFIX)
@@ -111,7 +112,8 @@ class CalendarWidgetProvider : AppWidgetProvider() {
             if (dayNumber in 1..daysInMonth) {
                 val date = yearMonth.atDay(dayNumber)
                 val dayOfWeek = date.dayOfWeek
-                val isHoliday = holidays.contains(date)
+                val isUserHoliday = CalendarRepository.isUserHoliday(date)
+                val isHoliday = isUserHoliday || holidays.contains(date)
                 val isToday = date == LocalDate.now()
                 val topColor = when {
                     isHoliday -> R.color.calendar_holiday_bg
@@ -128,10 +130,12 @@ class CalendarWidgetProvider : AppWidgetProvider() {
                     isHoliday || dayOfWeek == DayOfWeek.SUNDAY -> R.color.calendar_sunday_text
                     else -> R.color.widget_text_primary
                 }
+                val marksText = CalendarRepository.getMarks(date).joinToString("") { it.symbol }
 
                 views.setTextViewText(numberId, dayNumber.toString())
                 views.setTextColor(numberId, context.getColor(textColor))
-                views.setTextViewText(markId, "")
+                views.setTextViewText(markId, marksText)
+                views.setTextColor(markId, context.getColor(textColor))
                 views.setInt(topAreaId, "setBackgroundColor", context.getColor(topColor))
                 views.setInt(bottomAreaId, "setBackgroundColor", context.getColor(bottomColor))
             } else {

--- a/app/src/main/java/com/example/just_right_calendar/MainActivity.kt
+++ b/app/src/main/java/com/example/just_right_calendar/MainActivity.kt
@@ -65,6 +65,8 @@ class MainActivity : AppCompatActivity() {
         val daysInMonth = currentMonth.lengthOfMonth()
         val startOffset = ((firstDay.dayOfWeek.value + 6) % 7)
 
+        val cellHeightPx = calculateCellHeight()
+
         repeat(42) { index ->
             val dayNumber = index - startOffset + 1
             val date = if (dayNumber in 1..daysInMonth) {
@@ -72,12 +74,12 @@ class MainActivity : AppCompatActivity() {
             } else {
                 null
             }
-            val dayView = createDayCell(date)
+            val dayView = createDayCell(date, cellHeightPx)
             calendarGrid.addView(dayView)
         }
     }
 
-    private fun createDayCell(date: LocalDate?): View {
+    private fun createDayCell(date: LocalDate?, cellHeightPx: Int): View {
         val inflater = LayoutInflater.from(this)
         val view = inflater.inflate(R.layout.day_cell, calendarGrid, false)
 
@@ -86,11 +88,9 @@ class MainActivity : AppCompatActivity() {
         val topArea = view.findViewById<LinearLayout>(R.id.dayTopArea)
         val bottomArea = view.findViewById<LinearLayout>(R.id.dayBottomArea)
 
-        val horizontalPadding = dpToPx(32f)
-        val cellWidthPx = (resources.displayMetrics.widthPixels - horizontalPadding) / 7f
         val params = GridLayout.LayoutParams().apply {
             width = 0
-            height = (cellWidthPx * 1.5f).toInt()
+            height = cellHeightPx
             columnSpec = GridLayout.spec(GridLayout.UNDEFINED, 1f)
             rowSpec = GridLayout.spec(GridLayout.UNDEFINED, 1f)
         }
@@ -134,6 +134,16 @@ class MainActivity : AppCompatActivity() {
         dayNumber.setTextColor(ContextCompat.getColor(this, textColor))
 
         return view
+    }
+
+    private fun calculateCellHeight(): Int {
+        val horizontalPadding = dpToPx(32f)
+        val columnWidth = if (calendarGrid.width > 0) {
+            calendarGrid.width / 7f
+        } else {
+            (resources.displayMetrics.widthPixels - horizontalPadding) / 7f
+        }
+        return (columnWidth * (3f / 2f)).toInt()
     }
 
     private fun dpToPx(dp: Float): Int {


### PR DESCRIPTION
## Summary
- compute calendar day cell height with a 3:2 aspect ratio based on the grid width
- initialize repository access for widgets and display user holidays and marks in each day cell

## Testing
- ./gradlew test *(fails: SDK location not found in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943f230eee883219d8cecb4cbb4aa0e)