### PR TITLE
Add day detail editing and mark styling

### DIFF
--- a/app/src/main/java/com/example/just_right_calendar/CalendarWidgetProvider.kt
+++ b/app/src/main/java/com/example/just_right_calendar/CalendarWidgetProvider.kt
@@ -135,7 +135,7 @@ class CalendarWidgetProvider : AppWidgetProvider() {
                 views.setTextViewText(numberId, dayNumber.toString())
                 views.setTextColor(numberId, context.getColor(textColor))
                 views.setTextViewText(markId, marksText)
-                views.setTextColor(markId, context.getColor(textColor))
+                views.setTextColor(markId, context.getColor(R.color.calendar_mark_text))
                 views.setInt(topAreaId, "setBackgroundColor", context.getColor(topColor))
                 views.setInt(bottomAreaId, "setBackgroundColor", context.getColor(bottomColor))
             } else {

--- a/app/src/main/java/com/example/just_right_calendar/DayDetailActivity.kt
+++ b/app/src/main/java/com/example/just_right_calendar/DayDetailActivity.kt
@@ -1,11 +1,70 @@
 package com.example.just_right_calendar
 
 import android.os.Bundle
+import android.widget.Button
+import android.widget.CheckBox
+import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.SwitchCompat
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.format.DateTimeFormatter
+import java.time.format.TextStyle
+import java.util.Locale
 
 class DayDetailActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_day_detail)
+
+        CalendarRepository.initialize(applicationContext)
+
+        val date = intent.getStringExtra(EXTRA_DATE)?.let(LocalDate::parse) ?: run {
+            finish()
+            return
+        }
+
+        val dateLabel: TextView = findViewById(R.id.dateLabel)
+        val dayTypeLabel: TextView = findViewById(R.id.dayTypeLabel)
+        val markCircle: CheckBox = findViewById(R.id.markCircle)
+        val markCheck: CheckBox = findViewById(R.id.markCheck)
+        val markStar: CheckBox = findViewById(R.id.markStar)
+        val holidayToggle: SwitchCompat = findViewById(R.id.holidayToggle)
+        val saveButton: Button = findViewById(R.id.saveButton)
+
+        val formatter = DateTimeFormatter.ofPattern("yyyy年M月d日")
+        val dayOfWeek = date.dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.JAPAN)
+        dateLabel.text = "${date.format(formatter)} (${dayOfWeek})"
+
+        val marks = CalendarRepository.getMarks(date)
+        markCircle.isChecked = marks.contains(MarkType.CIRCLE)
+        markCheck.isChecked = marks.contains(MarkType.CHECK)
+        markStar.isChecked = marks.contains(MarkType.STAR)
+
+        val holidayName = JapaneseHolidayCalculator.holidaysForMonth(YearMonth.of(date.year, date.month))[date]
+        val isUserHoliday = CalendarRepository.isUserHoliday(date)
+        holidayToggle.isChecked = isUserHoliday
+
+        dayTypeLabel.text = when {
+            isUserHoliday -> getString(R.string.user_holiday_label)
+            holidayName != null -> holidayName
+            else -> dayOfWeek
+        }
+
+        saveButton.setOnClickListener {
+            val selectedMarks = mutableSetOf<MarkType>()
+            if (markCircle.isChecked) selectedMarks.add(MarkType.CIRCLE)
+            if (markCheck.isChecked) selectedMarks.add(MarkType.CHECK)
+            if (markStar.isChecked) selectedMarks.add(MarkType.STAR)
+
+            CalendarRepository.saveMarks(date, selectedMarks)
+            CalendarRepository.saveHoliday(date, holidayToggle.isChecked)
+
+            finish()
+        }
+    }
+
+    companion object {
+        const val EXTRA_DATE = "extra_date"
     }
 }

--- a/app/src/main/java/com/example/just_right_calendar/MainActivity.kt
+++ b/app/src/main/java/com/example/just_right_calendar/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.example.just_right_calendar
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -14,7 +15,6 @@ import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.YearMonth
 import java.time.format.DateTimeFormatter
-import kotlin.math.min
 
 class MainActivity : AppCompatActivity() {
     private lateinit var calendarGrid: GridLayout
@@ -52,6 +52,11 @@ class MainActivity : AppCompatActivity() {
             renderCalendar()
         }
 
+        renderCalendar()
+    }
+
+    override fun onResume() {
+        super.onResume()
         renderCalendar()
     }
 
@@ -108,6 +113,7 @@ class MainActivity : AppCompatActivity() {
 
         val marks = CalendarRepository.getMarks(date)
         markText.text = marks.joinToString("") { it.symbol }
+        markText.setTextColor(ContextCompat.getColor(this, R.color.calendar_mark_text))
 
         val isToday = date == LocalDate.now()
         val isHoliday = CalendarRepository.isUserHoliday(date)
@@ -132,6 +138,15 @@ class MainActivity : AppCompatActivity() {
         topArea.setBackgroundColor(ContextCompat.getColor(this, topColor))
         bottomArea.setBackgroundColor(ContextCompat.getColor(this, bottomColor))
         dayNumber.setTextColor(ContextCompat.getColor(this, textColor))
+
+        view.setOnClickListener {
+            startActivity(
+                Intent(this, DayDetailActivity::class.java).putExtra(
+                    DayDetailActivity.EXTRA_DATE,
+                    date.toString(),
+                ),
+            )
+        }
 
         return view
     }

--- a/app/src/main/res/layout/day_cell.xml
+++ b/app/src/main/res/layout/day_cell.xml
@@ -50,7 +50,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:gravity="center"
-                android:textColor="@color/text_primary"
+                android:textColor="@color/calendar_mark_text"
                 android:textSize="@dimen/mark_text_default_size"
                 android:textStyle="bold"
                 android:includeFontPadding="false"

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -20,6 +20,7 @@
     <color name="calendar_holiday_bg">#5A2C2C</color>
     <color name="calendar_saturday_bg">#1E3C78</color>
     <color name="calendar_sunday_text">#EF5350</color>
+    <color name="calendar_mark_text">#EF5350</color>
     <color name="calendar_default_day_bg">@color/input_background</color>
 
     <color name="widget_bg">@color/surface_background</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -20,6 +20,7 @@
     <color name="calendar_holiday_bg">#F5B8B8</color>
     <color name="calendar_saturday_bg">#7FA6FF</color>
     <color name="calendar_sunday_text">#D32F2F</color>
+    <color name="calendar_mark_text">#D32F2F</color>
     <color name="calendar_default_day_bg">@color/input_background</color>
 
     <color name="widget_bg">@color/surface_background</color>


### PR DESCRIPTION
## Summary
- open a day detail screen from calendar cells to adjust holiday toggle and marks
- implement detail screen logic to load/save mark selections and holiday state
- color calendar marks red in both the app view and widget

## Testing
- ./gradlew test *(fails: Android SDK location missing in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943f79850c48321984aa7c893a5d5c2)