### PR TITLE
Add widget launch intent and month navigation

### DIFF
--- a/app/src/main/res/layout/widget_calendar.xml
+++ b/app/src/main/res/layout/widget_calendar.xml
@@ -7,15 +7,44 @@
     android:background="@color/widget_bg"
     android:padding="8dp">
 
-    <TextView
-        android:id="@+id/widgetMonthLabel"
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:gravity="center"
-        android:textColor="@color/widget_text_primary"
-        android:textSize="18sp"
-        android:textStyle="bold"
-        android:paddingBottom="8dp" />
+        android:paddingBottom="8dp">
+
+        <TextView
+            android:id="@+id/widgetMonthLabel"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:textColor="@color/widget_text_primary"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="horizontal">
+
+            <View
+                android:id="@+id/widgetPrevMonthArea"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:background="@android:color/transparent"
+                android:clickable="true"
+                android:focusable="true" />
+
+            <View
+                android:id="@+id/widgetNextMonthArea"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:background="@android:color/transparent"
+                android:clickable="true"
+                android:focusable="true" />
+        </LinearLayout>
+    </FrameLayout>
 
     <LinearLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
## Summary
- Launch the main app when the calendar widget is tapped
- Add left/right swipe areas to move the widget month view while preserving per-widget state

## Testing
- ./gradlew test *(fails: Android SDK not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943fa495d1c83218ee2d6dd1c52b58f)