### PR TITLE
Add national holidays to main calendar view

### DIFF
--- a/app/src/main/java/com/yam1c6a/justrightcalendar/MainActivity.kt
+++ b/app/src/main/java/com/yam1c6a/justrightcalendar/MainActivity.kt
@@ -69,6 +69,7 @@ class MainActivity : AppCompatActivity() {
         val firstDay = currentMonth.atDay(1)
         val daysInMonth = currentMonth.lengthOfMonth()
         val startOffset = ((firstDay.dayOfWeek.value + 6) % 7)
+        val holidays = JapaneseHolidayCalculator.holidaysForMonth(currentMonth)
 
         val cellHeightPx = calculateCellHeight()
 
@@ -79,12 +80,16 @@ class MainActivity : AppCompatActivity() {
             } else {
                 null
             }
-            val dayView = createDayCell(date, cellHeightPx)
+            val dayView = createDayCell(date, cellHeightPx, holidays)
             calendarGrid.addView(dayView)
         }
     }
 
-    private fun createDayCell(date: LocalDate?, cellHeightPx: Int): View {
+    private fun createDayCell(
+        date: LocalDate?,
+        cellHeightPx: Int,
+        holidays: Map<LocalDate, String>,
+    ): View {
         val inflater = LayoutInflater.from(this)
         val view = inflater.inflate(R.layout.day_cell, calendarGrid, false)
 
@@ -116,7 +121,7 @@ class MainActivity : AppCompatActivity() {
         markText.setTextColor(ContextCompat.getColor(this, R.color.calendar_mark_text))
 
         val isToday = date == LocalDate.now()
-        val isHoliday = CalendarRepository.isUserHoliday(date)
+        val isHoliday = CalendarRepository.isUserHoliday(date) || holidays.containsKey(date)
         val dayOfWeek = date.dayOfWeek
 
         val topColor = when {

--- a/app/src/test/java/com/yam1c6a/justrightcalendar/JapaneseHolidayCalculatorTest.kt
+++ b/app/src/test/java/com/yam1c6a/justrightcalendar/JapaneseHolidayCalculatorTest.kt
@@ -1,0 +1,14 @@
+package com.yam1c6a.justrightcalendar
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+import java.time.YearMonth
+
+class JapaneseHolidayCalculatorTest {
+    @Test
+    fun `coming of age day 2026 is detected`() {
+        val holidays = JapaneseHolidayCalculator.holidaysForMonth(YearMonth.of(2026, 1))
+        assertTrue(holidays.containsKey(LocalDate.of(2026, 1, 12)))
+    }
+}


### PR DESCRIPTION
## Summary
- show national holidays computed by JapaneseHolidayCalculator in the main calendar grid
- add a unit test to ensure Coming of Age Day 2026 is recognized

## Testing
- not run (Android SDK not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69452add865c832183d4f69fba9b875e)