### PR TITLE
Add widget update triggers

### DIFF
--- a/app/src/main/java/com/yam1c6a/justrightcalendar/DayDetailActivity.kt
+++ b/app/src/main/java/com/yam1c6a/justrightcalendar/DayDetailActivity.kt
@@ -60,6 +60,8 @@ class DayDetailActivity : AppCompatActivity() {
             CalendarRepository.saveMarks(date, selectedMarks)
             CalendarRepository.saveHoliday(date, holidayToggle.isChecked)
 
+            CalendarWidgetProvider.requestWidgetUpdate(applicationContext)
+
             finish()
         }
     }

--- a/app/src/main/java/com/yam1c6a/justrightcalendar/MainActivity.kt
+++ b/app/src/main/java/com/yam1c6a/justrightcalendar/MainActivity.kt
@@ -58,6 +58,7 @@ class MainActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         renderCalendar()
+        CalendarWidgetProvider.requestWidgetUpdate(applicationContext)
     }
 
     private fun renderCalendar() {


### PR DESCRIPTION
## Summary
- refresh widgets when the app opens, day details are saved, or widgets become available
- add forced update handling and schedule daily midnight refreshes for the widget

## Testing
- ./gradlew test *(fails: Android SDK not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949346226588321a7e2705ea26724c4)