### PR TITLE
Ensure daily widget updates after boot

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -32,6 +34,16 @@
             <meta-data
                 android:name="android.appwidget.provider"
                 android:resource="@xml/calendar_widget_info" />
+        </receiver>
+
+        <receiver
+            android:name=".BootCompletedReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
+            </intent-filter>
         </receiver>
     </application>
 

--- a/app/src/main/java/com/yam1c6a/justrightcalendar/BootCompletedReceiver.kt
+++ b/app/src/main/java/com/yam1c6a/justrightcalendar/BootCompletedReceiver.kt
@@ -1,0 +1,22 @@
+package com.yam1c6a.justrightcalendar
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+
+class BootCompletedReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context?, intent: Intent?) {
+        val action = intent?.action ?: return
+        if (action == Intent.ACTION_BOOT_COMPLETED || action == Intent.ACTION_LOCKED_BOOT_COMPLETED) {
+            Log.d(TAG, "Boot completed; requesting widget update")
+            val safeContext = context?.applicationContext ?: return
+            CalendarWidgetProvider.requestWidgetUpdate(safeContext)
+            CalendarWidgetProvider.scheduleMidnightUpdate(safeContext)
+        }
+    }
+
+    companion object {
+        private const val TAG = "BootCompletedReceiver"
+    }
+}

--- a/app/src/main/java/com/yam1c6a/justrightcalendar/CalendarWidgetProvider.kt
+++ b/app/src/main/java/com/yam1c6a/justrightcalendar/CalendarWidgetProvider.kt
@@ -209,21 +209,6 @@ class CalendarWidgetProvider : AppWidgetProvider() {
         scheduleMidnightUpdate(context)
     }
 
-    private fun scheduleMidnightUpdate(context: Context) {
-        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as? AlarmManager ?: return
-        val now = ZonedDateTime.now()
-        val nextMidnight = now.truncatedTo(ChronoUnit.DAYS).plusDays(1)
-        val triggerAtMillis = nextMidnight.toInstant().toEpochMilli()
-        val pendingIntent = PendingIntent.getBroadcast(
-            context,
-            MIDNIGHT_REQUEST_CODE,
-            Intent(context, CalendarWidgetProvider::class.java).apply { action = ACTION_MIDNIGHT_UPDATE },
-            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
-        )
-        alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, pendingIntent)
-        Log.d(TAG, "Midnight update scheduled at $nextMidnight")
-    }
-
     private fun resolveIds(context: Context, prefix: String, suffix: String): List<Int> {
         val packageName = context.packageName
         return (1..42).mapNotNull { index ->
@@ -263,6 +248,21 @@ class CalendarWidgetProvider : AppWidgetProvider() {
                 action = ACTION_FORCE_UPDATE
             }
             context.sendBroadcast(updateIntent)
+        }
+
+        fun scheduleMidnightUpdate(context: Context) {
+            val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as? AlarmManager ?: return
+            val now = ZonedDateTime.now()
+            val nextMidnight = now.truncatedTo(ChronoUnit.DAYS).plusDays(1)
+            val triggerAtMillis = nextMidnight.toInstant().toEpochMilli()
+            val pendingIntent = PendingIntent.getBroadcast(
+                context,
+                MIDNIGHT_REQUEST_CODE,
+                Intent(context, CalendarWidgetProvider::class.java).apply { action = ACTION_MIDNIGHT_UPDATE },
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
+            alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, pendingIntent)
+            Log.d(TAG, "Midnight update scheduled at $nextMidnight")
         }
     }
 }


### PR DESCRIPTION
## Summary
- expose midnight update scheduling from the widget provider
- trigger midnight scheduling when the device boots to keep daily updates running

## Testing
- gradlew test *(fails: Android SDK not configured in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e2a1032f88321a1f4bc20b8f6c0f0)