### PR TITLE
Add new mark options and update widget default size

### DIFF
--- a/app/src/main/java/com/yam1c6a/justrightcalendar/CalendarRepository.kt
+++ b/app/src/main/java/com/yam1c6a/justrightcalendar/CalendarRepository.kt
@@ -36,7 +36,8 @@ object CalendarRepository {
         if (marks.isEmpty()) {
             editor.remove(marksKey(date))
         } else {
-            editor.putString(marksKey(date), marks.joinToString(",") { it.name })
+            val orderedMarks = MarkType.orderedMarks(marks)
+            editor.putString(marksKey(date), orderedMarks.joinToString(",") { it.name })
         }
         editor.apply()
     }

--- a/app/src/main/java/com/yam1c6a/justrightcalendar/CalendarWidgetProvider.kt
+++ b/app/src/main/java/com/yam1c6a/justrightcalendar/CalendarWidgetProvider.kt
@@ -170,7 +170,7 @@ class CalendarWidgetProvider : AppWidgetProvider() {
                     isHoliday || dayOfWeek == DayOfWeek.SUNDAY -> R.color.calendar_sunday_text
                     else -> R.color.widget_text_primary
                 }
-                val marksText = CalendarRepository.getMarks(date).joinToString("") { it.symbol }
+                val marksText = MarkType.orderedMarks(CalendarRepository.getMarks(date)).joinToString("") { it.symbol }
 
                 views.setTextViewText(numberId, dayNumber.toString())
                 views.setTextColor(numberId, context.getColor(textColor))

--- a/app/src/main/java/com/yam1c6a/justrightcalendar/DayDetailActivity.kt
+++ b/app/src/main/java/com/yam1c6a/justrightcalendar/DayDetailActivity.kt
@@ -26,9 +26,11 @@ class DayDetailActivity : AppCompatActivity() {
 
         val dateLabel: TextView = findViewById(R.id.dateLabel)
         val dayTypeLabel: TextView = findViewById(R.id.dayTypeLabel)
+        val markDoubleCircle: CheckBox = findViewById(R.id.markDoubleCircle)
         val markCircle: CheckBox = findViewById(R.id.markCircle)
         val markCheck: CheckBox = findViewById(R.id.markCheck)
         val markStar: CheckBox = findViewById(R.id.markStar)
+        val markTriangle: CheckBox = findViewById(R.id.markTriangle)
         val holidayToggle: SwitchCompat = findViewById(R.id.holidayToggle)
         val saveButton: Button = findViewById(R.id.saveButton)
 
@@ -37,9 +39,11 @@ class DayDetailActivity : AppCompatActivity() {
         dateLabel.text = "${date.format(formatter)} (${dayOfWeek})"
 
         val marks = CalendarRepository.getMarks(date)
+        markDoubleCircle.isChecked = marks.contains(MarkType.DOUBLE_CIRCLE)
         markCircle.isChecked = marks.contains(MarkType.CIRCLE)
         markCheck.isChecked = marks.contains(MarkType.CHECK)
         markStar.isChecked = marks.contains(MarkType.STAR)
+        markTriangle.isChecked = marks.contains(MarkType.TRIANGLE)
 
         val holidayName = JapaneseHolidayCalculator.holidaysForMonth(YearMonth.of(date.year, date.month))[date]
         val isUserHoliday = CalendarRepository.isUserHoliday(date)
@@ -53,9 +57,11 @@ class DayDetailActivity : AppCompatActivity() {
 
         saveButton.setOnClickListener {
             val selectedMarks = mutableSetOf<MarkType>()
+            if (markDoubleCircle.isChecked) selectedMarks.add(MarkType.DOUBLE_CIRCLE)
             if (markCircle.isChecked) selectedMarks.add(MarkType.CIRCLE)
             if (markCheck.isChecked) selectedMarks.add(MarkType.CHECK)
             if (markStar.isChecked) selectedMarks.add(MarkType.STAR)
+            if (markTriangle.isChecked) selectedMarks.add(MarkType.TRIANGLE)
 
             CalendarRepository.saveMarks(date, selectedMarks)
             CalendarRepository.saveHoliday(date, holidayToggle.isChecked)

--- a/app/src/main/java/com/yam1c6a/justrightcalendar/MainActivity.kt
+++ b/app/src/main/java/com/yam1c6a/justrightcalendar/MainActivity.kt
@@ -118,7 +118,7 @@ class MainActivity : AppCompatActivity() {
         dayNumber.text = date.dayOfMonth.toString()
 
         val marks = CalendarRepository.getMarks(date)
-        markText.text = marks.joinToString("") { it.symbol }
+        markText.text = MarkType.orderedMarks(marks).joinToString("") { it.symbol }
         markText.setTextColor(ContextCompat.getColor(this, R.color.calendar_mark_text))
 
         val isToday = date == LocalDate.now()

--- a/app/src/main/java/com/yam1c6a/justrightcalendar/MarkType.kt
+++ b/app/src/main/java/com/yam1c6a/justrightcalendar/MarkType.kt
@@ -1,13 +1,19 @@
 package com.yam1c6a.justrightcalendar
 
 enum class MarkType(val symbol: String) {
+    DOUBLE_CIRCLE("◎"),
+    STAR("☆"),
     CIRCLE("〇"),
-    CHECK("✓"),
-    STAR("☆");
+    TRIANGLE("△"),
+    CHECK("✓");
 
     companion object {
         fun fromString(value: String?): MarkType? {
             return values().firstOrNull { it.name.equals(value, ignoreCase = true) }
+        }
+
+        fun orderedMarks(marks: Set<MarkType>): List<MarkType> {
+            return values().filter { marks.contains(it) }
         }
     }
 }

--- a/app/src/main/res/layout/activity_day_detail.xml
+++ b/app/src/main/res/layout/activity_day_detail.xml
@@ -44,25 +44,41 @@
             android:dividerPadding="8dp">
 
             <CheckBox
-                android:id="@+id/markCircle"
+                android:id="@+id/markDoubleCircle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="〇"
+                android:text="◎"
                 android:textSize="18sp" />
-
-            <CheckBox
-                android:id="@+id/markCheck"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="✓"
-                android:textSize="18sp"
-                android:layout_marginStart="16dp" />
 
             <CheckBox
                 android:id="@+id/markStar"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="☆"
+                android:textSize="18sp"
+                android:layout_marginStart="16dp" />
+
+            <CheckBox
+                android:id="@+id/markCircle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="〇"
+                android:textSize="18sp"
+                android:layout_marginStart="16dp" />
+
+            <CheckBox
+                android:id="@+id/markTriangle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="△"
+                android:textSize="18sp"
+                android:layout_marginStart="16dp" />
+
+            <CheckBox
+                android:id="@+id/markCheck"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="✓"
                 android:textSize="18sp"
                 android:layout_marginStart="16dp" />
         </LinearLayout>

--- a/app/src/main/res/xml/calendar_widget_info.xml
+++ b/app/src/main/res/xml/calendar_widget_info.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
-    android:minWidth="320dp"
-    android:minHeight="260dp"
+    android:minWidth="250dp"
+    android:minHeight="320dp"
     android:initialLayout="@layout/widget_calendar"
     android:updatePeriodMillis="0"
     android:resizeMode="horizontal|vertical"


### PR DESCRIPTION
## Summary
- add new mark types and reorder mark selection as requested
- display marks in the specified order across the app and widget
- adjust widget default size to 4x5 cells

## Testing
- ./gradlew test *(fails: Android SDK not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e2e9705c48321ba4ce407080c813c)