### PR TITLE
Improve midnight widget scheduling

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/yam1c6a/justrightcalendar/CalendarWidgetProvider.kt
+++ b/app/src/main/java/com/yam1c6a/justrightcalendar/CalendarWidgetProvider.kt
@@ -261,8 +261,13 @@ class CalendarWidgetProvider : AppWidgetProvider() {
                 Intent(context, CalendarWidgetProvider::class.java).apply { action = ACTION_MIDNIGHT_UPDATE },
                 PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
             )
-            alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, pendingIntent)
-            Log.d(TAG, "Midnight update scheduled at $nextMidnight")
+            if (alarmManager.canScheduleExactAlarms()) {
+                alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, pendingIntent)
+                Log.d(TAG, "Midnight update scheduled exactly at $nextMidnight")
+            } else {
+                alarmManager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, pendingIntent)
+                Log.w(TAG, "Exact alarm not allowed; scheduled inexact midnight update at $nextMidnight")
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add exact alarm permission and fallback scheduling so the widget can update around midnight even when exact alarms are blocked

## Testing
- `./gradlew test` *(fails: SDK location not found in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f5e0d54248321a9842a9083db8efc)